### PR TITLE
Implement module creating via lambda expression like jint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Yantra (Machine in Sanskrit) is a Managed JavaScript Engine for .NET Standard wr
 | YantraJS (With CSX Module Support)                              | [![NuGet](https://img.shields.io/nuget/v/YantraJS.svg?label=NuGet)](https://www.nuget.org/packages/YantraJS)                           |
 | YantraJS.Core (Compiler)| [![NuGet](https://img.shields.io/nuget/v/YantraJS.Core.svg?label=NuGet)](https://www.nuget.org/packages/YantraJS.Core) |
 | YantraJS.ExpressionCompiler (IL Compiler)           | [![NuGet](https://img.shields.io/nuget/v/YantraJS.ExpressionCompiler.svg?label=NuGet)](https://www.nuget.org/packages/YantraJS.ExpressionCompiler) |
+| Yantra JS.ModuleExtensions (Fluent interface for module registration) | [![Nuget](https://img.shields.io/nuget/v/YantraJS.ModuleExtensions?label=NuGet&style=flat-square)](https://www.nuget.org/packages/YantraJS.ModuleExtensions) |
 
 # Features
 1. Compiles JavaScript to .Net Assembly 

--- a/YantraJS.Core.Tests/ModuleBuilderTests.cs
+++ b/YantraJS.Core.Tests/ModuleBuilderTests.cs
@@ -39,10 +39,21 @@ namespace YantraJS.Tests
         
 
         [TestMethod]
+        public async Task SyntheticDefaultMethod()
+        {
+            JSModuleContext context = new JSModuleContext();
+            context.CreateModule("test", x => x.ExportType<TestClass>());
+            var val1 = await context.RunScriptAsync("import { TestClass } from 'test' \nexport default new TestClass().foo()", string.Empty);
+            var val2 = await context.RunScriptAsync("import * as Test from 'test' \nexport default new Test.TestClass().foo()", string.Empty);
+            //Assert.AreEqual(val1, val2);
+        }
+
+
+        [TestMethod]
         public async Task ExportFunctionShouldWork()
         {
             JSModuleContext context = new JSModuleContext();
-            context.CreateModule("test", x => x.ExportFunction("lmao", new JSFunction(TestMethod)));
+            context.CreateModule("test", x => x.ExportFunction("lmao", TestMethod));
             var modulereturn = await context.RunScriptAsync("import {lmao} from 'test' \nexport default lmao()",
                 String.Empty);
             if (modulereturn[KeyStrings.@default] is JSString str)

--- a/YantraJS.Core.Tests/ModuleBuilderTests.cs
+++ b/YantraJS.Core.Tests/ModuleBuilderTests.cs
@@ -43,9 +43,9 @@ namespace YantraJS.Tests
         {
             JSModuleContext context = new JSModuleContext();
             context.CreateModule("test", x => x.ExportType<TestClass>());
-            var val1 = await context.RunScriptAsync("import { TestClass } from 'test' \nexport default new TestClass().foo()", string.Empty);
+            var val1 = await context.RunScriptAsync("import Test from 'test' \nexport default new Test.TestClass().foo()", string.Empty);
             var val2 = await context.RunScriptAsync("import * as Test from 'test' \nexport default new Test.TestClass().foo()", string.Empty);
-            //Assert.AreEqual(val1, val2);
+            Assert.AreEqual(val1[KeyStrings.@default] as JSString, val2[@KeyStrings.@default] as JSString);
         }
 
 

--- a/YantraJS.Core.Tests/ModuleBuilderTests.cs
+++ b/YantraJS.Core.Tests/ModuleBuilderTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YantraJS.Core;
+
+namespace YantraJS.Tests
+{
+    [TestClass]
+    public class ModuleBuilderTests
+    {
+        public JSValue TestMethod(in Arguments a)
+        {
+            return new JSString("bar");
+        }
+        private readonly JSModuleContext _context;
+
+        public ModuleBuilderTests()
+        {
+            _context = new JSModuleContext();
+        }
+
+        [TestMethod]
+        public async Task ModuleBuilderShouldWord()
+        {
+            _context.RegisterModule("test", builder =>
+            {
+                builder.ExportType<TestClass>()
+                    .ExportFunction("testFunc", TestMethod);
+            } );
+            var barfromclass = await _context
+                .RunScriptAsync("import {testFunc} from \"test\"\n export default testFunc();",
+                    String.Empty);
+            if (barfromclass is JSString str)
+            {
+                Assert.AreEqual("bar", barfromclass.StringValue);
+            }
+            
+        }
+        
+    }
+    public class TestClass
+    {
+        public string Foo() => "bar";
+    }
+}

--- a/YantraJS.Core.Tests/ModuleBuilderTests.cs
+++ b/YantraJS.Core.Tests/ModuleBuilderTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YantraJS.ModuleExtensions;
 using YantraJS.Core;
 
 namespace YantraJS.Tests
@@ -45,6 +46,8 @@ namespace YantraJS.Tests
             context.CreateModule("test", x => x.ExportType<TestClass>());
             var val1 = await context.RunScriptAsync("import Test from 'test' \nexport default new Test.TestClass().foo()", string.Empty);
             var val2 = await context.RunScriptAsync("import * as Test from 'test' \nexport default new Test.TestClass().foo()", string.Empty);
+            var val1str = val1[KeyStrings.@default] as JSString;
+            var val2str = val2[@KeyStrings.@default] as JSString;
             Assert.AreEqual(val1[KeyStrings.@default] as JSString, val2[@KeyStrings.@default] as JSString);
         }
 

--- a/YantraJS.Core.Tests/YantraJS.Core.Tests.csproj
+++ b/YantraJS.Core.Tests/YantraJS.Core.Tests.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\YantraJS.ModuleExtensions\YantraJS.ModuleExtensions.csproj" />
     <ProjectReference Include="..\YantraJS.Core\YantraJS.Core.csproj" />
   </ItemGroup>
 

--- a/YantraJS.Core/Core/Module/JSModuleContext.cs
+++ b/YantraJS.Core/Core/Module/JSModuleContext.cs
@@ -52,6 +52,13 @@ namespace YantraJS.Core
             moduleCache.GetOrCreate(name.Value, () => new JSModule(this, exports, n));
         }
 
+        public void RegisterModule(in KeyString name, Action<ModuleBuilder> builder)
+        {
+            var modulebuilder = new ModuleBuilder(name ,this);
+            builder.Invoke(modulebuilder);
+            modulebuilder.Build();
+        }
+
         /// <summary>
         /// Modules are isolated by Context and are identified by Id.
         /// 

--- a/YantraJS.Core/Core/Module/JSModuleContext.cs
+++ b/YantraJS.Core/Core/Module/JSModuleContext.cs
@@ -45,19 +45,45 @@ namespace YantraJS.Core
             this[KeyStrings.global] = this;
         }
 
+        
+        /// <summary>
+        /// Pass Exports as Module with unique name
+        /// After register module can get in script
+        /// <example>
+        ///  //in js script
+        /// import module from "module_name_that_used_in_name_arg";
+        /// import {prop in export object} from "module_name";
+        /// const module = require("module_name_that_used_in_name_arg");
+        /// const {some_prop} = require("module_name_that_used_in_name_arg");
+        /// </example>
+        /// </summary>
+        /// <param name="name">Unique module name</param>
+        /// <param name="exports">JSObject, that you import by import or require</param>
         public void RegisterModule(in KeyString name, JSObject exports)
         {
             var n = name.ToString();
             moduleCache.GetOrCreate(name.Value, () => new JSModule(this, exports, n));
         }
-
+        
+        
+        
+        /// <summary>
+        /// An analogue of the <see cref="RegisterModule"/> with fluent interface of creating module
+        /// </summary>
+        /// <param name="moduleName">Unique module name</param>
+        /// <param name="builder">Action delegate with <see cref="ModuleBuilder"/> object that use for configuring</param>
         public void CreateModule(string moduleName, Action<ModuleBuilder> builder)
         {
             var mb = new ModuleBuilder(moduleName);
             builder(mb); 
             mb.AddModuleToContext(this);
         }
-
+        /// <summary>
+        /// Return JSValue which is a module in js script (require function for c# code side)
+        /// </summary>
+        /// <param name="name">Module name</param>
+        /// <returns cref="JSValue">Module object</returns>
+        /// <exception cref="ArgumentException">If module not found</exception>
         public JSValue ImportModule(in KeyString name)
         {
             var n = name.Value;
@@ -206,7 +232,17 @@ namespace YantraJS.Core
                 await w;
             return r;
         }
-
+        
+        
+        /// <summary>
+        /// Run JavaScript module from string
+        /// </summary>
+        /// <param name="script">string of code</param>
+        /// <param name="moduleFolder">base folder for searching modules in import function</param>
+        /// <param name="paths"></param>
+        /// <param name="uniqueModuleID">Module ID if you want get this module later (in <see cref="ImportModule"/> or import in js)</param>
+        /// <returns>Module as JSObject</returns>
+        /// <exception cref="JSException"></exception>
         public async Task<JSValue> RunScriptAsync(
             string script,
             string moduleFolder,

--- a/YantraJS.Core/Core/Module/JSModuleContext.cs
+++ b/YantraJS.Core/Core/Module/JSModuleContext.cs
@@ -67,28 +67,7 @@ namespace YantraJS.Core
         
         
         
-        /// <summary>
-        /// An analogue of the <see cref="RegisterModule"/> with fluent interface of creating module
-        /// </summary>
-        /// <param name="moduleName">Unique module name</param>
-        /// <param name="builder">Action delegate with <see cref="ModuleBuilder"/> object that use for configuring</param>
-        public void CreateModule(string moduleName, Action<ModuleBuilder> builder)
-        {
-            var mb = new ModuleBuilder(moduleName);
-            builder(mb); 
-            mb.AddModuleToContext(this);
-        }
-        /// <summary>
-        /// Return JSValue which is a module in js script (require function for c# code side)
-        /// </summary>
-        /// <param name="name">Module name</param>
-        /// <returns cref="JSValue">Module object</returns>
-        /// <exception cref="ArgumentException">If module not found</exception>
-        public JSValue ImportModule(in KeyString name)
-        {
-            var n = name.Value;
-            return moduleCache.GetOrCreate(name.Value, () => throw new ArgumentException($"module {n} not found"));
-        }
+       
 
         /// <summary>
         /// Modules are isolated by Context and are identified by Id.

--- a/YantraJS.Core/Core/Module/ModuleBuilder.cs
+++ b/YantraJS.Core/Core/Module/ModuleBuilder.cs
@@ -1,43 +1,63 @@
 ﻿using System;
+using System.Collections.Generic;
+using YantraJS.Core;
 using YantraJS.Core.Clr;
-
-namespace YantraJS.Core;
 
 public class ModuleBuilder
 {
-    private readonly KeyString _moduleName;
-    private readonly JSModuleContext _moduleContext;
-    private readonly JSObject _exportobj;
+    private List<Type> exportedTypes = new();
+    private List<(string name, JSValue value)> exportedValues = new();
+    private List<(string name, JSFunction func)> exportedFunctions = new();
+    private string _moduleName;
 
-    internal ModuleBuilder(KeyString moduleName,JSModuleContext moduleContext)
+    public ModuleBuilder ExportType<T>(string name = null)
+    {
+        exportedTypes.Add(typeof(T));
+        return this;
+    }
+
+    public ModuleBuilder(string moduleName)
     {
         _moduleName = moduleName;
-        _moduleContext = moduleContext;
-        _exportobj = new JSObject();
     }
 
-    public ModuleBuilder ExportType<T>()
+    public ModuleBuilder ExportType(Type type, string name = null)
     {
-        string name = typeof(T).Name;
-        var type = ClrType.From(typeof(T));
-        _exportobj[name] = type;
+        exportedTypes.Add(type);
         return this;
     }
 
-    public ModuleBuilder ExportValue(in KeyString name, object value)
+    public ModuleBuilder ExportValue(string name, object value)
     {
-        _exportobj[name] = value.Marshal();
+        exportedValues.Add((name, value.Marshal()));
         return this;
     }
 
-    public ModuleBuilder ExportFunction(string name, JSFunctionDelegate func)
+    public ModuleBuilder ExportFunction(string name, JSFunction func)
     {
-        _exportobj[name] = new JSFunction(func);
+        exportedFunctions.Add((name, func));
         return this;
     }
 
-    internal void Build()
+    public void AddModuleToContext(JSModuleContext context)
     {
-        _moduleContext.RegisterModule(_moduleName, _exportobj);
+        JSObject exports = new JSObject();
+        foreach (var type in exportedTypes)
+        {
+            exports[type.Name] = ClrType.From(type);
+        }
+
+        foreach (var (name, value) in exportedValues)
+        {
+            exports[name] = value;
+        }
+
+        foreach (var (name, func) in exportedFunctions)
+        {
+            exports[name] = func;
+        }
+
+        context.RegisterModule(_moduleName, exports);
     }
 }
+

--- a/YantraJS.Core/Core/Module/ModuleBuilder.cs
+++ b/YantraJS.Core/Core/Module/ModuleBuilder.cs
@@ -10,7 +10,7 @@ public class ModuleBuilder
     private List<(string name, JSFunction func)> exportedFunctions = new();
     private string _moduleName;
 
-    public ModuleBuilder ExportType<T>(string name = null)
+    public ModuleBuilder ExportType<T>()
     {
         exportedTypes.Add(typeof(T));
         return this;

--- a/YantraJS.Core/Core/Module/ModuleBuilder.cs
+++ b/YantraJS.Core/Core/Module/ModuleBuilder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using YantraJS.Core.Clr;
+
+namespace YantraJS.Core;
+
+public class ModuleBuilder
+{
+    private readonly KeyString _moduleName;
+    private readonly JSModuleContext _moduleContext;
+    private readonly JSObject _exportobj;
+
+    internal ModuleBuilder(KeyString moduleName,JSModuleContext moduleContext)
+    {
+        _moduleName = moduleName;
+        _moduleContext = moduleContext;
+        _exportobj = new JSObject();
+    }
+
+    public ModuleBuilder ExportType<T>()
+    {
+        string name = typeof(T).Name;
+        var type = ClrType.From(typeof(T));
+        _exportobj[name] = type;
+        return this;
+    }
+
+    public ModuleBuilder ExportValue(in KeyString name, object value)
+    {
+        _exportobj[name] = value.Marshal();
+        return this;
+    }
+
+    public ModuleBuilder ExportFunction(string name, JSFunctionDelegate func)
+    {
+        _exportobj[name] = new JSFunction(func);
+        return this;
+    }
+
+    internal void Build()
+    {
+        _moduleContext.RegisterModule(_moduleName, _exportobj);
+    }
+}

--- a/YantraJS.Core/Core/Module/ModuleBuilder.cs
+++ b/YantraJS.Core/Core/Module/ModuleBuilder.cs
@@ -50,6 +50,8 @@ public class ModuleBuilder
             };
             
         }
+
+        globalExport[KeyStrings.@default] = globalExport;
         context.RegisterModule(_moduleName, globalExport);
     }
 }

--- a/YantraJS.ModuleExtensions/JSModuleContextExtension.cs
+++ b/YantraJS.ModuleExtensions/JSModuleContextExtension.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+using YantraJS.Core;
+
+namespace YantraJS.ModuleExtensions;
+
+public static class JSModuleContextExtension
+{
+    /// <summary>
+    /// An analogue of the <see cref="RegisterModule"/> with fluent interface of creating module
+    /// </summary>
+    /// <param name="moduleName">Unique module name</param>
+    /// <param name="builder">Action delegate with <see cref="ModuleBuilder"/> object that use for configuring</param>
+    public static void CreateModule(this JSModuleContext context, string moduleName, Action<ModuleBuilder> builder)
+    {
+        var mb = new ModuleBuilder(moduleName);
+        builder(mb); 
+        mb.AddModuleToContext(context);
+    }
+    /// <summary>
+    /// Return JSValue which is a module in js script (require function for c# code side)
+    /// </summary>
+    /// <param name="name">Module name</param>
+    /// <returns cref="JSValue">Module object</returns>
+    /// <exception cref="ArgumentException">If module not found</exception>
+    public static JSValue ImportModule(this JSModuleContext context, in KeyString name)
+    {
+        FieldInfo fi = typeof(JSModuleContext).GetField("moduleCache", BindingFlags.NonPublic | BindingFlags.Instance);
+        var moduleCache = (ModuleCache) fi.GetValue(context);
+        var n = name.Value;
+        return moduleCache.GetOrCreate(n, () => throw new ArgumentException($"module {n} not found"));
+    }
+}

--- a/YantraJS.ModuleExtensions/JSModuleContextExtension.cs
+++ b/YantraJS.ModuleExtensions/JSModuleContextExtension.cs
@@ -2,32 +2,33 @@
 using System.Reflection;
 using YantraJS.Core;
 
-namespace YantraJS.ModuleExtensions;
-
-public static class JSModuleContextExtension
+namespace YantraJS.ModuleExtensions
 {
-    /// <summary>
-    /// An analogue of the <see cref="RegisterModule"/> with fluent interface of creating module
-    /// </summary>
-    /// <param name="moduleName">Unique module name</param>
-    /// <param name="builder">Action delegate with <see cref="ModuleBuilder"/> object that use for configuring</param>
-    public static void CreateModule(this JSModuleContext context, string moduleName, Action<ModuleBuilder> builder)
+    public static class JSModuleContextExtension
     {
-        var mb = new ModuleBuilder(moduleName);
-        builder(mb); 
-        mb.AddModuleToContext(context);
-    }
-    /// <summary>
-    /// Return JSValue which is a module in js script (require function for c# code side)
-    /// </summary>
-    /// <param name="name">Module name</param>
-    /// <returns cref="JSValue">Module object</returns>
-    /// <exception cref="ArgumentException">If module not found</exception>
-    public static JSValue ImportModule(this JSModuleContext context, in KeyString name)
-    {
-        FieldInfo fi = typeof(JSModuleContext).GetField("moduleCache", BindingFlags.NonPublic | BindingFlags.Instance);
-        var moduleCache = (ModuleCache) fi.GetValue(context);
-        var n = name.Value;
-        return moduleCache.GetOrCreate(n, () => throw new ArgumentException($"module {n} not found"));
+        /// <summary>
+        /// An analogue of the <see cref="RegisterModule"/> with fluent interface of creating module
+        /// </summary>
+        /// <param name="moduleName">Unique module name</param>
+        /// <param name="builder">Action delegate with <see cref="ModuleBuilder"/> object that use for configuring</param>
+        public static void CreateModule(this JSModuleContext context, string moduleName, Action<ModuleBuilder> builder)
+        {
+            var mb = new ModuleBuilder(moduleName);
+            builder(mb); 
+            mb.AddModuleToContext(context);
+        }
+        /// <summary>
+        /// Return JSValue which is a module in js script (require function for c# code side)
+        /// </summary>
+        /// <param name="name">Module name</param>
+        /// <returns cref="JSValue">Module object</returns>
+        /// <exception cref="ArgumentException">If module not found</exception>
+        public static JSValue ImportModule(this JSModuleContext context, in KeyString name)
+        {
+            FieldInfo fi = typeof(JSModuleContext).GetField("moduleCache", BindingFlags.NonPublic | BindingFlags.Instance);
+            var moduleCache = (ModuleCache) fi.GetValue(context);
+            var n = name.Value;
+            return moduleCache.GetOrCreate(n, () => throw new ArgumentException($"module {n} not found"));
+        }
     }
 }

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
@@ -12,7 +12,7 @@ Adding fluent interface for module registering.</Description>
         <PackageProjectUrl>http://yantrajs.com/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/yantrajs/yantra</RepositoryUrl>
         <PackageVersion>1.0.1</PackageVersion>
-        <NuspecFile>./YantraJS.ModuleExtensions.nuspec</NuspecFile>
+        <NuspecFile>YantraJS.ModuleExtensions.nuspec</NuspecFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <ImplicitUsings>false</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>default</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\YantraJS.Core\YantraJS.Core.csproj" />
+      <ProjectReference Include="..\YantraJS.ExpressionCompiler\YantraJS.ExpressionCompiler.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
@@ -11,6 +11,8 @@
 Adding fluent interface for module registering.</Description>
         <PackageProjectUrl>http://yantrajs.com/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/yantrajs/yantra</RepositoryUrl>
+        <PackageVersion>1.0.1</PackageVersion>
+        <NuspecFile>./YantraJS.ModuleExtensions.nuspec</NuspecFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.csproj
@@ -5,6 +5,12 @@
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Authors>ZverGuy, ackava</Authors>
+        <Description>Bunch of extensions for JSModuleContext
+Adding fluent interface for module registering.</Description>
+        <PackageProjectUrl>http://yantrajs.com/</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/yantrajs/yantra</RepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
@@ -16,6 +16,6 @@ Adding fluent interface for module registering.</description>
     </dependencies>
   </metadata>
   <files>
-    <file src=".\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
+    <file src=".\bin\Debug\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
   </files>
 </package>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>YantraJS.ModuleExtensions</id>
+    <version>1.0.5</version>
+    <authors>ZverGuy, ackava</authors>
+    <projectUrl>http://yantrajs.com/</projectUrl>
+    <description>Bunch of extensions for JSModuleContext
+Adding fluent interface for module registering.</description>
+    <repository url="https://github.com/yantrajs/yantra" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="YantraJS.Core" version="1.2.42" exclude="Build,Analyzers" />
+        <dependency id="YantraJS.ExpressionCompiler" version="1.2.42" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="C:\Users\Мария\RiderProjects\yantra\YantraJS.ModuleExtensions\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
+  </files>
+</package>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
@@ -16,6 +16,6 @@ Adding fluent interface for module registering.</description>
     </dependencies>
   </metadata>
   <files>
-    <file src="C:\Users\Мария\RiderProjects\yantra\YantraJS.ModuleExtensions\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
+    <file src=".\YantraJS.ModuleExtensions\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
   </files>
 </package>

--- a/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
+++ b/YantraJS.ModuleExtensions/YantraJS.ModuleExtensions.nuspec
@@ -16,6 +16,6 @@ Adding fluent interface for module registering.</description>
     </dependencies>
   </metadata>
   <files>
-    <file src=".\YantraJS.ModuleExtensions\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
+    <file src=".\bin\Release\netstandard2.0\YantraJS.ModuleExtensions.dll" target="lib\netstandard2.0\YantraJS.ModuleExtensions.dll" />
   </files>
 </package>

--- a/YantraJS.sln
+++ b/YantraJS.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YantraJS.NodePollyfill", "Y
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YantraJS.ExpressionCompiler.Tests", "YantraJS.ExpressionCompiler.Tests\YantraJS.ExpressionCompiler.Tests.csproj", "{56196EFB-172B-4C4F-AC0A-3C6C5BCF72F3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YantraJS.ModuleExtensions", "YantraJS.ModuleExtensions\YantraJS.ModuleExtensions.csproj", "{5FF9CAEF-F7A6-449A-A24E-E03C9A705ABF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{56196EFB-172B-4C4F-AC0A-3C6C5BCF72F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{56196EFB-172B-4C4F-AC0A-3C6C5BCF72F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{56196EFB-172B-4C4F-AC0A-3C6C5BCF72F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FF9CAEF-F7A6-449A-A24E-E03C9A705ABF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FF9CAEF-F7A6-449A-A24E-E03C9A705ABF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FF9CAEF-F7A6-449A-A24E-E03C9A705ABF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FF9CAEF-F7A6-449A-A24E-E03C9A705ABF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added new methods:
```csharp
public void CreateModule(string moduleName, Action<ModuleBuilder> builder)
public JSValue ImportModule(in KeyString name)
```
Example of use

```csharp
//Module name must be unique)
context.CreateModule("test", x => x.ExportType<TestClass>());
context.CreateModule("test2", x => x.ExportFunction("lmao", new JSFunction(TestMethod)));

TestClass @class = new TestClass();
context.CreateModule("test3", x => x.ExportValue("t", @class));

 JSValue val = context.ImportModule("test"); //it throw ArgumentException if module not founded;

```
