### PR TITLE
Change builds to be in Release mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build -c Release --no-restore
 #    - name: Test
-#      run: dotnet test --no-build --verbosity normal
+#      run: dotnet test -c Release --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack --no-restore
+      run: dotnet pack -c Release --no-restore
     - name: Publish Eternity
       run: dotnet nuget push **/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json -n true
       env:


### PR DESCRIPTION
Release mode enables optimizations and also allows better comparison between engines when using BenchmarkDotNet (by default it gives an error about non-release artifacts being tested).