### PR TITLE
Fix a `EnsureSufficientExecutionStack` method for older versions of .NET

### DIFF
--- a/YantraJS.Core/Core/JSContextExtensions.cs
+++ b/YantraJS.Core/Core/JSContextExtensions.cs
@@ -19,6 +19,7 @@ namespace YantraJS.Core.Core
             try
             {
                 RuntimeHelpers.EnsureSufficientExecutionStack();
+                return;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Hello, Akash!

After upgrading to version 1.2.192, even running simple code on older versions of .NET leads to errors like this:

```
YantraJS.Core.JSException: RangeError: undefined
   at YantraJS.Core.Core.JSContextExtensions.EnsureSufficientExecutionStack(JSContext context)
   at YantraJS.Core.CallStackItem..ctor(JSContext context, String fileName, StringSpan& function, Int32 line, Int32 column)
   at body-:0,0(Closures , Arguments& )
   at YantraJS.Core.JSContext.Eval(String code, String codeFilePath)
   …
```

This PR fixes a error.